### PR TITLE
Allow for arrays of complex objects that don't have mementos

### DIFF
--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -155,9 +155,9 @@ component{
 			//writeDump( var="Processing: #item#" );
 
 			// Is this a nested include?
-			if( item.listLen( "." ) > 1 ){
+			if( listLen( item,  "." ) > 1 ){
 				// Retrieve the relationship
-				item = item.listFirst( "." );
+				item = listFirst( item, "." );
 			}
 
 			// Retrieve Value for transformation: ACF Incompats Suck on elvis operator
@@ -272,7 +272,7 @@ component{
 				return listFirst( target, "." ) == root && listLen( target, "." ) > 1;
 			} )
 			.map( function( target ){
-				return target.listDeleteAt( 1, "." );
+				return listDeleteAt( target, 1, "." );
 			} );
 
 		// var results = [];

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -210,13 +210,19 @@ component{
 				// Map Items into result object
 				result[ item ] = [];
 				for( var thisIndex = 1; thisIndex <= arrayLen( thisValue ); thisIndex++ ){
-					result[ item ][ thisIndex ] = thisValue[ thisIndex ].getMemento(
-						includes 		= $buildNestedMementoList( includes, item ),
-						excludes 		= $buildNestedMementoList( excludes, item ),
-						mappers 		= mappers,
-						defaults 		= defaults,
-						ignoreDefaults 	= ignoreDefaults
-					);
+					 // only get mementos from relationships that have mementos, in the event that we have an already-serialized array of structs
+					if( structKeyExists( thisValue[ thisIndex ], 'memento' ) ) {
+						result[ item ][ thisIndex ] = thisValue[ thisIndex ].getMemento(
+							includes 		= $buildNestedMementoList( includes, item ),
+							excludes 		= $buildNestedMementoList( excludes, item ),
+							mappers 		= mappers,
+							defaults 		= defaults,
+							ignoreDefaults 	= ignoreDefaults
+						);
+					}
+					else {
+						result[ item ][ thisIndex ] = thisValue [ thisIndex ];
+					}
 				}
 			}
 

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -211,7 +211,8 @@ component{
 				result[ item ] = [];
 				for( var thisIndex = 1; thisIndex <= arrayLen( thisValue ); thisIndex++ ){
 					 // only get mementos from relationships that have mementos, in the event that we have an already-serialized array of structs
-					if( structKeyExists( thisValue[ thisIndex ], 'memento' ) ) {
+					if( isStruct( thisValue[ thisIndex ] ) && structKeyExists( thisValue[ thisIndex ], 'memento' ) ) { // only get mementos from relationships that have mementos
+			
 						result[ item ][ thisIndex ] = thisValue[ thisIndex ].getMemento(
 							includes 		= $buildNestedMementoList( includes, item ),
 							excludes 		= $buildNestedMementoList( excludes, item ),

--- a/test-harness/handlers/Main.cfc
+++ b/test-harness/handlers/Main.cfc
@@ -49,4 +49,41 @@
 		);
 	}
 
+	function alreadySerialized( event, rc, prc ){
+		param rc.ignoreDefaults = false;
+		param rc.includes = "";
+		param rc.excludes = "";
+
+		var mockData = {
+			fname = "testuser",
+			lname = "testuser",
+			email = "testuser@testuser.com",
+			username = "testuser",
+			isConfirmed = true,
+			isActive = true,
+			otherURL = "www.luismajano.com",
+			alreadySerialized = [
+				{
+					'foo'	= 'bar'
+				},
+				{
+					'baz'	= 'frobozz'
+				}
+			]
+		};
+
+		var oUser = populateModel(
+			model					= userService.new(),
+			memento 				= mockData,
+			composeRelationships	= true
+		);
+
+		return oUser.getMemento(
+			includes        = rc.includes,
+			excludes        = rc.excludes,
+			ignoreDefaults 	= rc.ignoreDefaults,
+			mappers = {}
+		);
+	}
+
 }

--- a/test-harness/models/User.cfc
+++ b/test-harness/models/User.cfc
@@ -26,6 +26,10 @@ component 	persistent="true"
 	property 	name="permissionList"
 				persistent="false";
 
+	property 	name="alreadySerialized"
+				type="array"
+				persistent="false";
+				
 	/* *********************************************************************
 	**						PROPERTIES
 	********************************************************************* */
@@ -157,7 +161,8 @@ component 	persistent="true"
 			"facebookURL",
 			"lastLogin",
 			"isConfirmed",
-			"avatarLink"
+			"avatarLink",
+			"alreadySerialized"
 		],
 		// Default Exclusions
 		defaultExcludes = [
@@ -190,6 +195,7 @@ component 	persistent="true"
 		variables.permissionList 	= "";
 		variables.APIToken 			= "";
 		variables.addToMailingList	= false;
+		variables.alreadySerialized = [];
 
 		// startup a token
 		generateAPIToken();

--- a/test-harness/tests/specs/MainTests.cfc
+++ b/test-harness/tests/specs/MainTests.cfc
@@ -22,6 +22,27 @@
 				expect( memento.lname ).toBe( "TESTUSER" );
 			});
 
+			it( "can render mementos even if the obejct has already-serialized data", function(){
+				var event = this.request( route="/main/alreadySerialized", params={} );
+				var memento = deserializeJSON( event.getRenderedContent() );
+				// Derfault INcludes + Excludes
+
+				expect( memento[ "alreadySerialized" ] )
+					.toBeArray()
+					.toHaveLength( 2 );
+
+				expect( memento [ "alreadySerialized" ][ 1 ] )
+					.toBeStruct()
+					.toHaveKey( 'foo' );
+
+				expect( memento [ "alreadySerialized" ][ 2 ] )
+					.toBeStruct()
+					.toHaveKey( 'baz' );
+
+				expect( memento[ "alreadySerialized" ][ 1 ][ 'foo' ] )
+					.toBe( 'bar' );
+			});
+
 
 		});
 


### PR DESCRIPTION
Resolves #4 
Add a test to verify new behavior
Note that it would probably be a good idea to add a test that it doesn't break the old behavior - it's a very simple change that just looks for the `memento` property, but since we haven't ever used the old behavior we didn't write a test for it.