### PR TITLE
Mementifier ORM Enhancements

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -32,7 +32,9 @@ component {
 			// Enable orm auto default includes: If true and an object doesn't have any `memento` struct defined
 			// this module will create it with all properties and relationships it can find for the target entity
 			// leveraging the cborm module.
-			ormAutoIncludes = true
+			ormAutoIncludes = true,
+			// The default value for getters which return null
+			nullDefaultValue = ''
 		};
 
 		// Custom Declared Interceptors

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -122,22 +122,14 @@ component{
 			}
 
 			var ormUtil = server.coldfusion.productname == "ColdFusion Server" ? new cborm.models.util.CFORMUtil() : new cborm.models.util.LuceeORMUtil(); 
+			var classMd = ormUtil.getSessionFactory( ormUtil.getEntityDatasource( thisName ) ).getClassMetaData( thisName );
 			var typeMap = arrayReduce( 
 								ormUtil.getSessionFactory( ormUtil.getEntityDatasource( thisName ) )
 									.getClassMetaData( thisName )
-									.getPropertyTypes(), 
-								function( mdTypes, propertyClass ){
-									var propertyName = propertyClass.getName();
-									var propertyClassName = getMetadata( propertyClass ).name;
-
-									if( findNoCase( "java.util.collection", propertyName ) ){
-										propertyName  = replaceNoCase(
-															replaceNoCase(
-																replaceNoCase( propertyName, "java.util.collection(", "" )
-																, ")", "" )
-															, thisName & ".", ""
-														);
-									}
+									.getPropertyNames(), 
+								function( mdTypes, propertyName ){
+									var propertyType = classMd.getPropertyType( propertyName );
+									var propertyClassName = getMetadata( propertyType ).name;
 
 									mdTypes[ propertyName ] = propertyClassName;
 									return mdTypes;

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -121,8 +121,9 @@ component{
 				thisName = ( md.keyExists( "entityName" ) ? md.entityName : listLast( md.name, "." ) );
 			}
 
+			var ormUtil = server.coldfusion.productname == "ColdFusion Server" ? new CFORMUtil() : new LuceeORMUtil(); 
 			var typeMap = arrayReduce( 
-								orm.getSessionFactory( orm.getEntityDatasource( thisName ) )
+								ormUtil.getSessionFactory( ormUtil.getEntityDatasource( thisName ) )
 									.getClassMetaData( thisName )
 									.getPropertyTypes(), 
 								function( mdTypes, propertyClass ){
@@ -160,7 +161,12 @@ component{
 			} );
 
 			// Append primary keys
-			var hibernateMD = getEntityMetadata( this );
+
+			var hibernateMD = ormUtil.getEntityMetadata(
+				entityName = thisName,
+				datasource = ormUtil.getEntityDatasource( this, structKeyExists( variables, "datasource" ) ? variables.datasource : ormUtil.getDefaultDatasource() )
+			);
+			
 			if( hibernateMD.hasIdentifierProperty() ){
 				arrayAppend( thisMemento.defaultIncludes, hibernateMD.getIdentifierPropertyName() );
 			} else if( thisMemento.defaultIncludes.getIdentifierType().isComponentType() ){

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -124,9 +124,7 @@ component{
 			var ormUtil = server.coldfusion.productname == "ColdFusion Server" ? new cborm.models.util.CFORMUtil() : new cborm.models.util.LuceeORMUtil(); 
 			var classMd = ormUtil.getSessionFactory( ormUtil.getEntityDatasource( thisName ) ).getClassMetaData( thisName );
 			var typeMap = arrayReduce( 
-								ormUtil.getSessionFactory( ormUtil.getEntityDatasource( thisName ) )
-									.getClassMetaData( thisName )
-									.getPropertyNames(), 
+								classMd.getPropertyNames(), 
 								function( mdTypes, propertyName ){
 									var propertyType = classMd.getPropertyType( propertyName );
 									var propertyClassName = getMetadata( propertyType ).name;

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -121,7 +121,7 @@ component{
 				thisName = ( md.keyExists( "entityName" ) ? md.entityName : listLast( md.name, "." ) );
 			}
 
-			var ormUtil = server.coldfusion.productname == "ColdFusion Server" ? new CFORMUtil() : new LuceeORMUtil(); 
+			var ormUtil = server.coldfusion.productname == "ColdFusion Server" ? new cborm.models.util.CFORMUtil() : new cborm.models.util.LuceeORMUtil(); 
 			var typeMap = arrayReduce( 
 								ormUtil.getSessionFactory( ormUtil.getEntityDatasource( thisName ) )
 									.getClassMetaData( thisName )

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -260,7 +260,7 @@ component{
 			}
 
 			// Array Collections
-			if( isArray( thisValue ) ){
+			else if( isArray( thisValue ) ){
 				// Map Items into result object
 				result[ item ] = [];
 				for( var thisIndex = 1; thisIndex <= arrayLen( thisValue ); thisIndex++ ){
@@ -282,7 +282,7 @@ component{
 			}
 
 			// Single Object Relationships
-			if( isObject( thisValue ) ){
+			else if( isValid( 'component', thisValue ) && structKeyExists( thisValue, "getMemento" ) ){
 				//writeDump( var=$buildNestedMementoList( includes, item ), label="includes: #item#" );
 				//writeDump( var=$buildNestedMementoList( excludes, item ), label="excludes: #item#" );
 				result[ item ] = thisValue.getMemento(
@@ -292,6 +292,9 @@ component{
 					defaults 		= defaults,
 					ignoreDefaults 	= ignoreDefaults
 				);
+			} else {
+				// we don't know what to do with this item so we return as-is
+				result[ item ] = thisValue;
 			}
 
 			// Result Mapper for Item Result

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -257,13 +257,14 @@ component{
 				for( var thisIndex = 1; thisIndex <= arrayLen( thisValue ); thisIndex++ ){
 					 // only get mementos from relationships that have mementos, in the event that we have an already-serialized array of structs
 					if( !isSimpleValue( thisValue[ thisIndex ] ) && structKeyExists( thisValue[ thisIndex ], "getMemento" ) ) {
-
+						var nestedIncludes = $buildNestedMementoList( includes, item );
 						result[ item ][ thisIndex ] = thisValue[ thisIndex ].getMemento(
-							includes 		= $buildNestedMementoList( includes, item ),
+							includes 		= nestedIncludes,
 							excludes 		= $buildNestedMementoList( excludes, item ),
 							mappers 		= mappers,
 							defaults 		= defaults,
-							ignoreDefaults 	= ignoreDefaults
+							// cascade the ignore defaults down if specific nested includes are requested
+							ignoreDefaults 	= nestedIncludes.len() ? ignoreDefaults : false
 						);
 
 					} else {
@@ -276,12 +277,14 @@ component{
 			else if( isValid( 'component', thisValue ) && structKeyExists( thisValue, "getMemento" ) ){
 				//writeDump( var=$buildNestedMementoList( includes, item ), label="includes: #item#" );
 				//writeDump( var=$buildNestedMementoList( excludes, item ), label="excludes: #item#" );
+				var nestedIncludes = $buildNestedMementoList( includes, item );
 				result[ item ] = thisValue.getMemento(
-					includes 		= $buildNestedMementoList( includes, item ),
+					includes 		= nestedIncludes,
 					excludes 		= $buildNestedMementoList( excludes, item ),
 					mappers 		= mappers,
 					defaults 		= defaults,
-					ignoreDefaults 	= ignoreDefaults
+					// cascade the ignore defaults down if specific nested includes are requested
+					ignoreDefaults 	= nestedIncludes.len() ? ignoreDefaults : false
 				);
 			} else {
 				// we don't know what to do with this item so we return as-is

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -121,12 +121,13 @@ component{
 				thisName = ( md.keyExists( "entityName" ) ? md.entityName : listLast( md.name, "." ) );
 			}
 
-			var ormUtil = server.coldfusion.productname == "ColdFusion Server" ? new cborm.models.util.CFORMUtil() : new cborm.models.util.LuceeORMUtil(); 
-			var classMd = ormUtil.getSessionFactory( ormUtil.getEntityDatasource( thisName ) ).getClassMetaData( thisName );
+			var ORMService = new cborm.models.BaseORMService();
+
+			var entityMd = ORMService.getEntityMetadata( this );
 			var typeMap = arrayReduce( 
-								classMd.getPropertyNames(), 
+								entityMd.getPropertyNames(), 
 								function( mdTypes, propertyName ){
-									var propertyType = classMd.getPropertyType( propertyName );
+									var propertyType = entityMd.getPropertyType( propertyName );
 									var propertyClassName = getMetadata( propertyType ).name;
 
 									mdTypes[ propertyName ] = propertyClassName;
@@ -151,16 +152,10 @@ component{
 			} );
 
 			// Append primary keys
-
-			var hibernateMD = ormUtil.getEntityMetadata(
-				entityName = thisName,
-				datasource = ormUtil.getEntityDatasource( this, structKeyExists( variables, "datasource" ) ? variables.datasource : ormUtil.getDefaultDatasource() )
-			);
-			
-			if( hibernateMD.hasIdentifierProperty() ){
-				arrayAppend( thisMemento.defaultIncludes, hibernateMD.getIdentifierPropertyName() );
+			if( entityMd.hasIdentifierProperty() ){
+				arrayAppend( thisMemento.defaultIncludes, entityMd.getIdentifierPropertyName() );
 			} else if( thisMemento.defaultIncludes.getIdentifierType().isComponentType() ){
-				arrayAppend( thisMemento.defaultIncludes, listToArray( arrayToList( hibernateMD.getIdentifierType().getPropertyNames() ) ), true );
+				arrayAppend( thisMemento.defaultIncludes, listToArray( arrayToList( entityMd.getIdentifierType().getPropertyNames() ) ), true );
 			}
 		}
 

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -225,7 +225,7 @@ component{
 				var thisValue = invoke( this, "get#item#" );
 				// Verify Nullness
 				thisValue = isNull( thisValue ) ? (
-					structKeyExists( thisMemento.defaults, item ) ? thisMemento.defaults[ item ] : ""
+					structKeyExists( thisMemento.defaults, item ) ? thisMemento.defaults[ item ] : $mementifierSettings.nullDefaultValue
 				) : thisValue;
 			} else {
 				// Calling for non-existent properties, skip out

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -295,14 +295,16 @@ component{
 
 			// Result Mapper for Item Result
 			if( mappersKeyArray.findNoCase( item ) ){
+				
 				// ACF compat
 				var thisMapper = thisMemento.mappers[ item ];
 				result[ item ] = thisMapper( result[ item ] );
-			}
 
-			// ensure anything left over is provided as the value
-			if( !structKeyExists( result, item ) ){
+			} else if( !structKeyExists( result, item ) ){
+				
+				// ensure anything left over is provided as the value
 				result[ item ] = thisValue;
+			
 			}
 
 		}

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,9 @@ moduleSettings = {
 		// Enable orm auto default includes: If true and an object doesn't have any `memento` struct defined
 		// this module will create it with all properties and relationships it can find for the target entity
 		// leveraging the cborm module.
-		ormAutoIncludes = true
+		ormAutoIncludes = true,
+		// The default value for relationships/getters which return null
+		nullDefaultValue = ''
 	}
 }
 ```


### PR DESCRIPTION
- resolves Issue #12 - infinite recursion with `ormAutoIncludes`
- resolves issue #10 - allows for processing of binary and Java objects
- resolves issue #11 - allows a configuration convention to override the default value on a null getter return

By using the session factory directly, the performance overhead of introspection on simple/complex value properties is minimal.