### PR TITLE
Allow defaults to be `null`

### DIFF
--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -238,7 +238,7 @@ component{
 
             // Verify Nullness
             thisValue = isNull( thisValue ) ? (
-				thisMemento.defaults.keyArray().containsNoCase( item ) ?
+				arrayContainsNoCase( thisMemento.defaults.keyArray(), item ) ?
 					( isNull( thisMemento.defaults[ item ] ) ? javacast( "null", "" ) : thisMemento.defaults[ item ] ) :
 					$mementifierSettings.nullDefaultValue
 			) : thisValue;

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -238,11 +238,16 @@ component{
 
             // Verify Nullness
             thisValue = isNull( thisValue ) ? (
-                structKeyExists( thisMemento.defaults, item ) ? thisMemento.defaults[ item ] : $mementifierSettings.nullDefaultValue
-            ) : thisValue;
-
+				thisMemento.defaults.keyArray().containsNoCase( item ) ?
+					( isNull( thisMemento.defaults[ item ] ) ? javacast( "null", "" ) : thisMemento.defaults[ item ] ) :
+					$mementifierSettings.nullDefaultValue
+			) : thisValue;
+			
+			if ( isNull( thisValue ) ) {
+				result[ item ] = javacast( "null", "" );
+			}
 			// Match timestamps + date/time objects
-			if(
+			else if(
 				isSimpleValue( thisValue )
 				&&
 				(
@@ -322,7 +327,7 @@ component{
 				var thisMapper = thisMemento.mappers[ key ];
 				return thisMapper( value, result );
             } else {
-                return value;
+                return isNull( value ) ? javacast( "null", "" ) : value;
             }
         } );
 


### PR DESCRIPTION
Currently, you can't use `null` as a default value inside the `defaults` struct.  This PR let's `null` propagate through.