### PR TITLE
Allow call site date formatting

### DIFF
--- a/models/ResultsMapper.cfc
+++ b/models/ResultsMapper.cfc
@@ -11,7 +11,7 @@
  * }
  * </pre>
  */
-component singleton{
+component singleton {
 
 	/**
 	 * Constructor
@@ -37,25 +37,21 @@ component singleton{
 	 */
 	function process(
 		required array collection,
-		id="id",
-		includes="",
-		excludes="",
-		struct mappers={},
-		struct defaults={},
-        boolean ignoreDefaults=false,
-        boolean trustedGetters
+		id                     = "id",
+		includes               = "",
+		excludes               = "",
+		struct mappers         = {},
+		struct defaults        = {},
+		boolean ignoreDefaults = false,
+		boolean trustedGetters
 	){
 		var args = arguments;
-		return arguments.collection
-			.reduce( function( accumulator, item ){
-				var id = invoke( arguments.item, "get#id#" );
-				arguments.accumulator.results.append( id );
-				arguments.accumulator.resultsMap[ id ] = item.getMemento( argumentCollection=args );
-				return arguments.accumulator;
-			}, {
-				"results" 		: [],
-				"resultsMap" 	: {}
-			} );
+		return arguments.collection.reduce( function( accumulator, item ){
+			var id = invoke( arguments.item, "get#id#" );
+			arguments.accumulator.results.append( id );
+			arguments.accumulator.resultsMap[ id ] = item.getMemento( argumentCollection = args );
+			return arguments.accumulator;
+		}, { "results" : [], "resultsMap" : {} } );
 	}
 
 }

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,12 @@ this.memento = {
     trustedGetters = $mementifierSettings.trustedGetters,
     // Enable orm auto default includes
     ormAutoIncludes = $mementifierSettings.ormAutoIncludes,
+    // Use the ISO 8601 formatter for this component
+    iso8601Format = $mementifierSettings.iso8601Format,
+    // Use a custom date mask for this component
+    dateMask = $mementifierSettings.dateMask,
+	// Use a custom time mask for this component
+    timeMask = $mementifierSettings.timeMask
 }
 ```
 
@@ -194,7 +200,10 @@ struct function getMemento(
 	struct mappers={},
 	struct defaults={},
     boolean ignoreDefaults=false,
-    boolean trustedGetters
+	boolean trustedGetters,
+	boolean iso8601Format,
+	string dateMask,
+	string timeMask
 )
 ```
 
@@ -221,7 +230,10 @@ struct function getMemento(
 	struct mappers={},
 	struct defaults={},
 	boolean ignoreDefaults=false,
-	boolean trustedGetters
+	boolean trustedGetters,
+	boolean iso8601Format,
+	string dateMask,
+	string timeMask
 ){
 	// Call mementifier
 	var memento	= this.$getMemento( argumentCollection=arguments );

--- a/test-harness/handlers/Main.cfc
+++ b/test-harness/handlers/Main.cfc
@@ -1,13 +1,13 @@
 ﻿component{
 
-	property name="userService"       inject="entityService:User";
-	property name="roleService"       inject="entityService:Role";
-	property name="settingService"    inject="entityService:Setting";
+	property name="userService"             inject="entityService:User";
+	property name="roleService"             inject="entityService:Role";
+	property name="settingService"       inject="entityService:Setting";
 	property name="permissionService" inject="entityService:Permission";
 
 	function index( event, rc, prc ){
 		param rc.ignoreDefaults = false;
-		param rc.ignoredRoots = "";
+		param rc.ignoredRoots   = "";
 		param rc.includes       = "";
 		param rc.excludes       = "";
 
@@ -46,10 +46,10 @@
 		);
 
 		var result = oUser.getMemento(
-			includes = rc.includes,
-			excludes = rc.excludes,
+			includes       = rc.includes,
+			excludes       = rc.excludes,
 			ignoreDefaults = rc.ignoreDefaults,
-			ignoredRoots = rc.ignoredRoots,
+			ignoredRoots   = rc.ignoredRoots,
             trustedGetters = event.valueExists( "trustedGetters" ) ?
                 rc.trustedGetters :
                 javacast( "null", "" ),
@@ -58,11 +58,17 @@
                 "foo" = function( _, memento ) {
                     return memento.fname & " " & memento.lname;
                 }
-			}
+			},
+			iso8601Format = event.valueExists( "iso8601Format" ) ?
+				rc.iso8601Format :
+				javacast( "null", "" ),
+			dateMask = event.valueExists( "dateMask" ) ?
+				rc.dateMask :
+				javacast( "null", "" ),
+			timeMask = event.valueExists( "timeMask" ) ?
+				rc.timeMask :
+				javacast( "null", "" )
 		);
-
-		writeDump( var=result );
-		abort;
 
 		return result;
 	}

--- a/test-harness/tests/specs/MainTests.cfc
+++ b/test-harness/tests/specs/MainTests.cfc
@@ -7,7 +7,7 @@
 			} );
 
 			it( "can render base mementos", function() {
-				var event = this.request( route="/main/index", params={} );
+				var event   = this.request( route="/main/index", params={} );
 				var memento = deserializeJSON( event.getRenderedContent() );
 				// Derfault INcludes + Excludes
 				expect( memento )
@@ -19,7 +19,9 @@
 			} );
 
 			it( "can render mementos even if the object has already-serialized data", function() {
-				var event = this.request( route="/main/alreadySerialized", params={} );
+				var event = this.request( route="/main/alreadySerialized", params={
+					"includes": "alreadySerialized"
+				} );
 				var memento = deserializeJSON( event.getRenderedContent() );
 				// Derfault INcludes + Excludes
 
@@ -51,8 +53,10 @@
 
             it( "can render inherited properties with wildcard default properties", function() {
                 var event = this.request(
-                    route="/main/index",
-                    params={ }
+                    route ="/main/index",
+                    params={
+						"includes": "createdDate,isActive"
+					}
                 );
 
 				var memento = deserializeJSON( event.getRenderedContent() );
@@ -67,7 +71,7 @@
 
             it( "can use a mapper for a property that does not exist", function() {
                 var event = this.request(
-                    route="/main/index",
+                    route ="/main/index",
                     params={
                         "includes": "foo"
                     }
@@ -83,7 +87,7 @@
 
             it( "skips properties that do not exist and do not have a mapper", function() {
                 var event = this.request(
-                    route = "/main/index",
+                    route  = "/main/index",
                     params = {
                         "includes": "doesntexist"
                     }
@@ -98,9 +102,9 @@
 
             it( "tries to retrieve all properties when trustedGetters is on even if the method does not seem to exist", function() {
                 var event = this.request(
-                    route = "/main/index",
+                    route  = "/main/index",
                     params = {
-                        "includes": "doesntexist",
+                        "includes"      : "doesntexist",
                         "trustedGetters": true
                     }
                 );
@@ -110,6 +114,51 @@
 				expect( memento ).toBeStruct();
 				expect( memento ).toHaveKey( "doesntexist" );
 				expect( memento.doesntexist ).toBe( "doesntexist" );
+			} );
+
+			it( "can specify iso8601 in the getMemento call", function() {
+                var event = this.request(
+                    route  = "/main/index",
+                    params = {
+						"includes": "createdDate",
+                        "iso8601Format": true
+                    }
+                );
+
+				var memento = deserializeJSON( event.getRenderedContent() );
+				expect( memento ).toBeStruct();
+				expect( memento ).toHaveKey( "createdDate" );
+				expect( memento.createdDate ).toInclude( "T" );
+			} );
+
+			it( "can specify a date mask in the getMemento call", function() {
+                var event = this.request(
+                    route  = "/main/index",
+                    params = {
+						"includes": "createdDate",
+                        "dateMask": "MMM d YYYY"
+                    }
+                );
+
+				var memento = deserializeJSON( event.getRenderedContent() );
+				expect( memento ).toBeStruct();
+				expect( memento ).toHaveKey( "createdDate" );
+				expect( listToArray( memento.createdDate, "" )[ 1 ] ).notToBeNumeric();
+			} );
+
+			it( "can specify a time mask in the getMemento call", function() {
+                var event = this.request(
+                    route  = "/main/index",
+                    params = {
+						"includes": "createdDate",
+                        "timeMask": "H"
+                    }
+                );
+
+				var memento = deserializeJSON( event.getRenderedContent() );
+				expect( memento ).toBeStruct();
+				expect( memento ).toHaveKey( "createdDate" );
+				expect( find( ":", memento.createdDate ) > 0 ).toBeFalse( "Should not find a : character." );
             } );
 		} );
 	}


### PR DESCRIPTION
With this, a component can include `iso8601Format`,  `dateMask`, and `timeMask` either in the `this.memento` settings or the `getMemento` call.  The normal cascade rules for the other memento properties apply.