### PR TITLE
fix: Correctly apply nested mappers

### DIFF
--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -88,6 +88,10 @@ component {
 				variables.$buildNestedMementoList
 			);
 			arguments.entity.$injectMixin(
+				"$buildNestedMementoStruct",
+				variables.$buildNestedMementoStruct
+			);
+			arguments.entity.$injectMixin(
 				"$getDeepProperties",
 				variables.$getDeepProperties
 			);
@@ -354,8 +358,8 @@ component {
 						result[ item ][ thisIndex ] = thisValue[ thisIndex ].getMemento(
 							includes       = nestedIncludes,
 							excludes       = $buildNestedMementoList( excludes, item ),
-							mappers        = mappers,
-							defaults       = defaults,
+							mappers        = $buildNestedMementoStruct( mappers, item ),
+							defaults       = $buildNestedMementoStruct( defaults, item ),
 							// cascade the ignore defaults down if specific nested includes are requested
 							ignoreDefaults = nestedIncludes.len() ? arguments.ignoreDefaults : false
 						);
@@ -377,8 +381,8 @@ component {
 				var thisItemMemento = thisValue.getMemento(
 					includes       = nestedIncludes,
 					excludes       = $buildNestedMementoList( excludes, item ),
-					mappers        = mappers,
-					defaults       = defaults,
+					mappers        = $buildNestedMementoStruct( mappers, item ),
+					defaults       = $buildNestedMementoStruct( defaults, item ),
 					// cascade the ignore defaults down if specific nested includes are requested
 					ignoreDefaults = nestedIncludes.len() ? arguments.ignoreDefaults : false
 				);
@@ -445,6 +449,23 @@ component {
 		// 	}
 		// }
 		// return results;
+	}
+
+	/**
+	 * Build a new memento mappers/defaults struct using the target list and a property root
+	 *
+	 * @struct The struct to use for construction
+	 * @root The root to filter out
+	 *
+	 * @return A struct of the new hiearchy to use
+	 */
+	function $buildNestedMementoStruct( required struct s, required string root ) {
+        return arguments.s.reduce( function( acc, key, value ) {
+            if ( listFirst( key, "." ) == root && listLen( key, "." ) > 1 ) {
+                acc[ listDeleteAt( key, 1, "." ) ] = value;
+            }
+            return acc;
+        }, {} );
 	}
 
 	/**

--- a/test-harness/handlers/Main.cfc
+++ b/test-harness/handlers/Main.cfc
@@ -73,6 +73,56 @@
 		return result;
 	}
 
+	function nested( event, rc, prc ) {
+		var mockData = {
+			fname       = "testuser",
+			lname       = "testuser",
+			email       = "testuser@testuser.com",
+			username    = "testuser",
+			isConfirmed = true,
+			isActive    = true,
+			otherURL    = "www.luismajano.com"
+		};
+
+		var oUser = populateModel(
+			model               = userService.new(),
+			memento             = mockData,
+			composeRelationships= true
+		);
+		oUser.setRole(
+			roleService.new( {
+				role       ="Admin",
+				description="Awesome Admin"
+			} )
+		);
+		oUser.getRole().setPermissions( [
+			permissionService.new( { permission="READ", description="read" } ),
+			permissionService.new( { permission="WRITE", description="write" } )
+		] );
+		oUser.setPermissions( [
+			permissionService.new( { permission="CUSTOM_READ", description="read" } ),
+			permissionService.new( { permission="CUSTOM_WRITE", description="write" } )
+		] );
+
+		oUser.setSettings(
+			[ getNewSetting(), getNewSetting(), getNewSetting(), getNewSetting(), getNewSetting() ]
+		);
+
+		var result = oUser.getMemento(
+			includes       = [ "role.permissions", "role.userId" ],
+			mappers = {
+                "description": function( item, memento ) {
+                    throw( "Should not be called" );
+                },
+                "role.permissions.description": function( item ) {
+                    return uCase( item );
+                }
+            }
+		);
+
+		return result;
+	}
+
 	private function getNewSetting(){
 		return settingService.new( {
 			name       : "setting-#createUUID()#",

--- a/test-harness/tests/specs/MainTests.cfc
+++ b/test-harness/tests/specs/MainTests.cfc
@@ -160,6 +160,19 @@
 				expect( memento ).toHaveKey( "createdDate" );
 				expect( find( ":", memento.createdDate ) > 0 ).toBeFalse( "Should not find a : character." );
             } );
+
+            it( "correctly passes nested mappers", function() {
+                expect( function() {
+                    var event = this.request(
+                        route  = "/main/nested",
+                        params = {}
+                    );
+
+                    var memento = deserializeJSON( event.getRenderedContent() );
+                    expect( memento.role.permissions[ 1 ].description ).toBeWithCase( "READ" );
+                    expect( memento.role.permissions[ 2 ].description ).toBeWithCase( "WRITE" );
+                } ).notToThrow();
+            } );
 		} );
 	}
 


### PR DESCRIPTION
Mappers would incorrectly be passed to all nested mementos meaning if a nested memento had the same key as an higher-level memento it would call the mapper.  This PR fixes that by scoping the mappers as nested mementos are called.

Co-Authored-By: @quinteroj