### PR TITLE
Composite keys and no default includes fails

### DIFF
--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -222,7 +222,7 @@ component {
 			// Append primary keys
 			if ( entityMd.hasIdentifierProperty() ) {
 				arrayAppend( thisMemento.defaultIncludes, entityMd.getIdentifierPropertyName() );
-			} else if ( thisMemento.defaultIncludes.getIdentifierType().isComponentType() ) {
+			} else if ( entityMd.getIdentifierType().isComponentType() ) {
 				arrayAppend(
 					thisMemento.defaultIncludes,
 					listToArray( arrayToList( entityMd.getIdentifierType().getPropertyNames() ) ),


### PR DESCRIPTION
When calling getMemento on an entity with more than one primary key and no default includes specified the call will fail with an error: 

The getIdentifierType method was not found. 
Either there are no methods with the specified method name and argument types or the getIdentifierType method is overloaded with argument types that ColdFusion cannot decipher reliably. ColdFusion found 0 methods that match the provided arguments. If this is a Java object and you verified that the method exists, use the javacast function to reduce ambiguity. 

This issue was previously fixed by https://github.com/coldbox-modules/mementifier/commit/bc1ac837127f3440a257f4b147be18536975fe3e but seems to have been reversed.