### PR TITLE
Feat/improve mementifier property type getter speed

### DIFF
--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -183,11 +183,8 @@ component {
 			var entityMd = ORMService.getEntityMetadata( this );
 			var typeMap  = arrayReduce(
 				entityMd.getPropertyNames(),
-				function( mdTypes, propertyName ){
-					var propertyType      = entityMd.getPropertyType( arguments.propertyName );
-					var propertyClassName = getMetadata( propertyType ).name;
-
-					arguments.mdTypes[ arguments.propertyName ] = propertyClassName;
+				function( mdTypes, propertyName, index ){
+					arguments.mdTypes[ arguments.propertyName ] = types[ index ].getClass().getName();
 					return arguments.mdTypes;
 				},
 				{}

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -181,6 +181,7 @@ component {
 			var ORMService = new cborm.models.BaseORMService();
 
 			var entityMd = ORMService.getEntityMetadata( this );
+			var types = entityMd.getPropertyTypes();
 			var typeMap  = arrayReduce(
 				entityMd.getPropertyNames(),
 				function( mdTypes, propertyName, index ){

--- a/readme.md
+++ b/readme.md
@@ -430,6 +430,17 @@ In order to collaborate on this project you will need to do a few things in orde
 
 Create a database called `mementifier` in any RDBMS you like. We have mostly used MySQL for the tests.
 
+This quick Docker command will get you started:
+
+```bash
+docker run --detach \
+	--publish 3306:3306 \
+	--name mementifier_mysql \
+	--env MYSQL_ROOT_PASSWORD=mysql \
+	--env MYSQL_DATABASE=mementifier \
+	mysql
+```
+
 ### Environment
 
 Copy the `.env.template` as `.env` and modify it accordingly so it can connect to your database.

--- a/test-harness/handlers/Main.cfc
+++ b/test-harness/handlers/Main.cfc
@@ -1,5 +1,6 @@
 ﻿component {
 
+	property name="postService"       inject="entityService:Post";
 	property name="userService"       inject="entityService:User";
 	property name="roleService"       inject="entityService:Role";
 	property name="settingService"    inject="entityService:Setting";
@@ -117,6 +118,22 @@
 		);
 
 		return result;
+	}
+
+	function post( event, rc, prc ){
+		var mockData = {
+			slug : "new-mementifier-release-wows-public",
+			title: "New Mementifier Release Wows Public",
+			teaser : "The new Mementifier release from Ortus Solutions impresses the public...",
+			createdBy : userService.new()
+		};
+
+		var oPost = populateModel(
+			model                = postService.new(),
+			memento              = mockData,
+			composeRelationships = true
+		);
+		return oPost.getMemento();
 	}
 
 	private function getNewSetting(){

--- a/test-harness/models/Post.cfc
+++ b/test-harness/models/Post.cfc
@@ -1,0 +1,64 @@
+/**
+ * A Post
+ */
+component 	persistent="true"
+			table="posts"
+			extends="BaseEntity"{
+
+
+	/* *********************************************************************
+	**						PROPERTIES
+	********************************************************************* */
+
+	property 	name="postId"
+				fieldtype="id"
+				generator="uuid"
+				length   ="36"
+				ormtype="string";
+
+	property 	name="slug"
+				notnull="true"
+				unique="true"
+				sqltype="varchar(255)";
+
+	property 	name="title"
+				notnull="true";
+
+	property 	name="teaser"
+				default=""
+				notnull="false";
+
+	property 	name="body"
+				default=""
+				notnull="false";
+
+	property 	name="isPublished"
+				ormtype="boolean"
+				default="false"
+				notnull="false";
+
+	property 	name="createdBy"
+				fieldtype="many-to-one"
+				lazy="true"
+				update="false"
+			  	cfc="User"
+			  	fkcolumn="FK_creationUser";
+
+	/* *********************************************************************
+	**						STATIC PROPERTIES & CONSTRAINTS
+	********************************************************************* */
+
+	// pk
+	this.pk = "postId";
+
+	// Test default mementification settings
+
+	/**
+	 * Constructor
+	 */
+	function init(){
+		super.init();
+		return this;
+	}
+
+}

--- a/test-harness/tests/specs/MainTests.cfc
+++ b/test-harness/tests/specs/MainTests.cfc
@@ -141,6 +141,13 @@
 				var memento = deserializeJSON( event.getRenderedContent() );
 				expect( memento ).toHaveKey( "token,firstName,lastName" );
 			} );
+
+			it( "Will use default includes if none specified", function(){
+				var event   = this.request( route = "/main/post", params = {} );
+				var memento = deserializeJSON( event.getRenderedContent() );
+				expect( memento ).toHaveKey( "slug,title,teaser,isActive,createdDate,updatedDate,postId" );
+				expect( memento ).notToHaveKey( "createdBy" );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Lucee's `getMetadata()` implementation is horrifically slow. By using the native Hibernate methods we have available, we can speed up property type introspection a ton.

Here's a real live example of 1,000 iterations of this code block going from 5.5+ seconds to < 60ms:

![Screenshot from 2022-08-31 11-55-02](https://user-images.githubusercontent.com/8106227/187727817-d061f31e-074e-4629-a38f-91acbe5b8082.png)
