### PR TITLE
Patch/build docs fix

### DIFF
--- a/build/Build.cfc
+++ b/build/Build.cfc
@@ -204,7 +204,6 @@ component {
 		fileSystemUtil.createMapping( arguments.projectName, variables.cwd );
 		// Generate Docs
 		print.greenLine( "Generating API Docs, please wait..." ).toConsole();
-		directoryCreate( arguments.outputDir, true, true );
 
 		command( "docbox generate" )
 			.params(

--- a/build/Build.cfc
+++ b/build/Build.cfc
@@ -130,9 +130,7 @@ component {
 			)
 			.toConsole();
 
-		// Prepare exports directory
-		variables.exportsDir = variables.artifactsDir & "/#projectName#/#arguments.version#";
-		directoryCreate( variables.exportsDir, true, true );
+		ensureExportDir( argumentCollection = arguments );
 
 		// Project Build Dir
 		variables.projectBuildDir = variables.buildDir & "/#projectName#";
@@ -200,6 +198,8 @@ component {
 		version   = "1.0.0",
 		outputDir = ".tmp/apidocs"
 	){
+		ensureExportDir( argumentCollection = arguments );
+
 		// Create project mapping
 		fileSystemUtil.createMapping( arguments.projectName, variables.cwd );
 		// Generate Docs
@@ -315,4 +315,18 @@ component {
 		return ( createObject( "java", "java.lang.System" ).getProperty( "cfml.cli.exitCode" ) ?: 0 );
 	}
 
+	/**
+	 * Ensure the export directory exists at artifacts/NAME/VERSION/
+	 */
+	private function ensureExportDir(
+		required projectName,
+		version   = "1.0.0"
+	){
+		if ( structKeyExists( variables, "exportsDir" ) && directoryExists( variables.exportsDir ) ){
+			return;
+		}
+		// Prepare exports directory
+		variables.exportsDir = variables.artifactsDir & "/#projectName#/#arguments.version#";
+		directoryCreate( variables.exportsDir, true, true );
+	}
 }


### PR DESCRIPTION
This PR corrects a few bugs in the `build:docs` box script:

1. An error when running `box run-script build:docs` because `variables.exportsDir` doesn't exist.
2. The `directoryCreate( outputDir )` is worse than useless, since DocBox creates this dir for you, and this code creates the wrong directory anyway! (it creates `.tmp/apidocs/` inside the `build/` directory, which is not where it should be.)