### PR TITLE
Allow nested items to use their own `this.memento` defaults, if not overridden

### DIFF
--- a/box.json
+++ b/box.json
@@ -27,9 +27,12 @@
         "commandbox-cfformat":"*",
         "commandbox-docbox":"*",
         "commandbox-dotenv":"*",
-        "commandbox-cfconfig":"*"
+        "commandbox-cfconfig":"*",
+        "cbMockData":"^4.1.0+3"
     },
-    "installPaths":{},
+    "installPaths":{
+        "cbMockData":"modules/cbMockData/"
+    },
     "ignore":[
         "**/.*",
         "build/**",

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -161,11 +161,13 @@ component {
 		};
 
 		// Param arguments according to instance > settings chain precedence
-		arguments.trustedGetters   = isNull( arguments.trustedGetters ) ? thisMemento.trustedGetters : arguments.trustedGetters;
-		arguments.iso8601Format    = isNull( arguments.iso8601Format ) ? thisMemento.iso8601Format : arguments.iso8601Format;
-		arguments.dateMask         = isNull( arguments.dateMask ) ? thisMemento.dateMask : arguments.dateMask;
-		arguments.timeMask         = isNull( arguments.timeMask ) ? thisMemento.timeMask : arguments.timeMask;
-		arguments.autoCastBooleans = isNull( arguments.autoCastBooleans ) ? thisMemento.autoCastBooleans : arguments.autoCastBooleans;
+		var flags = {
+			"trustedGetters"   = isNull( arguments.trustedGetters ) ? thisMemento.trustedGetters : arguments.trustedGetters,
+			"iso8601Format"    = isNull( arguments.iso8601Format ) ? thisMemento.iso8601Format : arguments.iso8601Format,
+			"dateMask"         = isNull( arguments.dateMask ) ? thisMemento.dateMask : arguments.dateMask,
+			"timeMask"         = isNull( arguments.timeMask ) ? thisMemento.timeMask : arguments.timeMask,
+			"autoCastBooleans" = isNull( arguments.autoCastBooleans ) ? thisMemento.autoCastBooleans : arguments.autoCastBooleans,
+		};
 
 		// Choose a profile
 		if ( len( arguments.profile ) && thisMemento.profiles.keyExists( arguments.profile ) ) {
@@ -178,9 +180,9 @@ component {
 
 		// Default formatter or customize it if passed arguments are different than settings.
 		var customDateFormatter = this.$FORMATTER_CUSTOM;
-		if ( arguments.dateMask != thisMemento.dateMask || arguments.timeMask != thisMemento.timeMask ) {
+		if ( flags.dateMask != thisMemento.dateMask || flags.timeMask != thisMemento.timeMask ) {
 			customDateFormatter = createObject( "java", "java.text.SimpleDateFormat" ).init(
-				"#arguments.dateMask# #arguments.timeMask#"
+				"#flags.dateMask# #flags.timeMask#"
 			);
 		}
 
@@ -275,12 +277,12 @@ component {
 				var thisAlias = item;
 			}
 
-			if ( arguments.trustedGetters || structKeyExists( this, "get#item#" ) ) {
+			if ( flags.trustedGetters || structKeyExists( this, "get#item#" ) ) {
 				try {
 					thisValue = invoke( this, "get#item#" );
 				} catch ( any e ) {
 					// Unless trusted getters is on and there is a mapper for this item rethrow the exception.
-					if ( !arguments.trustedGetters || !structKeyExists( arguments.mappers, item ) ) {
+					if ( !flags.trustedGetters || !structKeyExists( arguments.mappers, item ) ) {
 						rethrow;
 					}
 				}
@@ -319,7 +321,7 @@ component {
 					// Date Test just in case
 					dateInstance.getTime();
 					// Iso Date?
-					if ( arguments.iso8601Format ) {
+					if ( flags.iso8601Format ) {
 						// we need to convert trailing Zulu time designations offset or JS libs like Moment will not know how to parse it
 						result[ thisAlias ] = this.$FORMATTER_ISO8601.format( dateInstance ).replace( "Z", "+00:00" );
 					} else {
@@ -331,7 +333,7 @@ component {
 			}
 
 			// Strict Type Boolean Values
-			else if ( arguments.autoCastBooleans && !isNumeric( thisValue ) && isBoolean( thisValue ) ) {
+			else if ( flags.autoCastBooleans && !isNumeric( thisValue ) && isBoolean( thisValue ) ) {
 				result[ thisAlias ] = javacast( "Boolean", thisValue );
 			}
 
@@ -366,11 +368,11 @@ component {
 							ignoreDefaults  : nestedIncludes.len() ? arguments.ignoreDefaults : false,
 							// Cascade the arguments to the children
 							profile         : arguments.profile,
-							trustedGetters  : arguments.trustedGetters,
-							iso8601Format   : arguments.iso8601Format,
-							dateMask        : arguments.dateMask,
-							timeMask        : arguments.timeMask,
-							autoCastBooleans: arguments.autoCastBooleans
+							trustedGetters  : isNull( arguments.trustedGetters ) ? javacast( "null", "" ) : arguments.trustedGetters,
+							iso8601Format   : isNull( arguments.iso8601Format ) ? javacast( "null", "" ) : arguments.iso8601Format,
+							dateMask        : isNull( arguments.dateMask ) ? javacast( "null", "" ) : arguments.dateMask,
+							timeMask        : isNull( arguments.timeMask ) ? javacast( "null", "" ) : arguments.timeMask,
+							autoCastBooleans: isNull( arguments.autoCastBooleans ) ? javacast( "null", "" ) : arguments.autoCastBooleans
 						);
 					} else {
 						result[ thisAlias ][ thisIndex ] = thisValue[ thisIndex ];
@@ -396,11 +398,11 @@ component {
 					ignoreDefaults  : nestedIncludes.len() ? arguments.ignoreDefaults : false,
 					// Cascade the arguments to the children
 					profile         : arguments.profile,
-					trustedGetters  : arguments.trustedGetters,
-					iso8601Format   : arguments.iso8601Format,
-					dateMask        : arguments.dateMask,
-					timeMask        : arguments.timeMask,
-					autoCastBooleans: arguments.autoCastBooleans
+					trustedGetters  : isNull( arguments.trustedGetters ) ? javacast( "null", "" ) : arguments.trustedGetters,
+					iso8601Format   : isNull( arguments.iso8601Format ) ? javacast( "null", "" ) : arguments.iso8601Format,
+					dateMask        : isNull( arguments.dateMask ) ? javacast( "null", "" ) : arguments.dateMask,
+					timeMask        : isNull( arguments.timeMask ) ? javacast( "null", "" ) : arguments.timeMask,
+					autoCastBooleans: isNull( arguments.autoCastBooleans ) ? javacast( "null", "" ) : arguments.autoCastBooleans
 				);
 
 				// Do we have a root already for this guy?

--- a/interceptors/Mementifier.cfc
+++ b/interceptors/Mementifier.cfc
@@ -166,7 +166,7 @@ component {
 			"iso8601Format"    = isNull( arguments.iso8601Format ) ? thisMemento.iso8601Format : arguments.iso8601Format,
 			"dateMask"         = isNull( arguments.dateMask ) ? thisMemento.dateMask : arguments.dateMask,
 			"timeMask"         = isNull( arguments.timeMask ) ? thisMemento.timeMask : arguments.timeMask,
-			"autoCastBooleans" = isNull( arguments.autoCastBooleans ) ? thisMemento.autoCastBooleans : arguments.autoCastBooleans,
+			"autoCastBooleans" = isNull( arguments.autoCastBooleans ) ? thisMemento.autoCastBooleans : arguments.autoCastBooleans
 		};
 
 		// Choose a profile

--- a/server-adobe@2021.json
+++ b/server-adobe@2021.json
@@ -11,21 +11,21 @@
         "rewrites":{
             "enable":"true"
         },
-		"webroot":"test-harness",
+        "webroot":"test-harness",
         "aliases":{
             "/moduleroot/mementifier":"../"
         }
     },
-	"JVM":{
-		"heapSize":"768",
-		"javaVersion":"openjdk11_jre",
+    "JVM":{
+        "heapSize":"768",
+        "javaVersion":"openjdk11_jre",
         "args":"-Dcoldfusion.runtime.remotemethod.matchArguments=false"
     },
     "openBrowser":"false",
-	"cfconfig":{
+    "cfconfig":{
         "file":".cfconfig.json"
     },
-	"scripts" : {
+    "scripts":{
         "onServerInstall":"cfpm install zip,debugger,orm,mysql,postgresql,sqlserver,feed,chart"
     }
 }

--- a/test-harness/handlers/Main.cfc
+++ b/test-harness/handlers/Main.cfc
@@ -140,7 +140,7 @@
 
 	private function getNewSetting(
 		string name,
-		string description,
+		string description
 	){
 		param arguments.name = "setting-#createUUID()#";
 		param arguments.description = "Hola!!! from #arguments.name#";

--- a/test-harness/handlers/Main.cfc
+++ b/test-harness/handlers/Main.cfc
@@ -45,7 +45,7 @@
 			getNewSetting(),
 			getNewSetting(),
 			getNewSetting(),
-			getNewSetting()
+			getNewSetting( name = "Yes" )
 		] );
 
 
@@ -138,16 +138,20 @@
 		return oPost.getMemento();
 	}
 
-	private function getNewSetting(){
-		var description = "Hola!!! from #createUUID()#";
+	private function getNewSetting(
+		string name,
+		string description,
+	){
+		param arguments.name = "setting-#createUUID()#";
+		param arguments.description = "Hola!!! from #arguments.name#";
 
 		return settingService.new( {
-			name        : "setting-#createUUID()#",
-			description : description,
+			name        : arguments.name,
+			description : arguments.description,
 			isConfirmed : randRange( 0, 1 )
 		} ).setLatestValue(
 			recentValueService.new( {
-				description : description
+				description : arguments.description
 			} )
 		);
 	}

--- a/test-harness/models/Setting.cfc
+++ b/test-harness/models/Setting.cfc
@@ -55,10 +55,11 @@ component
 			"description"
 		],
 		// Default Exclusions
-		defaultExcludes : [],
-		neverInclude    : [],
+		defaultExcludes  : [],
+		neverInclude     : [],
 		// Defaults
-		defaults        : {}
+		defaults         : {},
+		autoCastBooleans : false
 	};
 
 	/**

--- a/test-harness/tests/specs/integration/MainTests.cfc
+++ b/test-harness/tests/specs/integration/MainTests.cfc
@@ -165,6 +165,17 @@
 					.toHaveKey( "latestValue" )
 					.toHaveDeepKey( "description" );
 			} );
+
+			it( "lets nested items figure out their own default settings unless the settings were explicitly passed in arguments", function(){
+				var event = this.request(
+					route  = "/",
+					params = { ignoreDefaults : true, includes : "fname,lname,settings" }
+				);
+				var memento = deserializeJSON( event.getRenderedContent() );
+				expect( memento.settings ).toBeArray().notToBeEmpty();
+				expect( arrayLast( memento.settings ) ).toHaveKey( "name" );
+				expect( arrayLast( memento.settings ).name ).toBeWithCase( "Yes" );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
# Description

It seems in mementifier the `autoCastBoolean` option is not respected for child items.
For example:
```
class Conversation {
    property name="id";
    property name="name";
    
    function latestMessage() {
        return belongsTo( "ConversationMessage", "latestMessageID" );
    }
}
```
```
class ConversationMessage {
    property name="id";
    property name="conversationID";
    property name="body" type="string" sqltype="CF_SQL_NVARCHAR";

    this.memento = { "defaultExcludes": [ "segments" ], "autoCastBooleans": false };
}
```
When calling `getMemento()` on a `Conversation`, it does not respect the `autoCastBooleans: false` in the `ConversationMessage`'s memento settings.


This seems to be the case for a few other flags as well:
```
// Process the item memento
result[ thisAlias ][ thisIndex ] = thisValue[ thisIndex ].getMemento(
	includes        : nestedIncludes,
	excludes        : $buildNestedMementoList( excludes, item ),
	mappers         : $buildNestedMementoStruct( mappers, item ),
	defaults        : $buildNestedMementoStruct( defaults, item ),
	// cascade the ignore defaults down if specific nested includes are requested
	ignoreDefaults  : nestedIncludes.len() ? arguments.ignoreDefaults : false,
	// Cascade the arguments to the children
	profile         : arguments.profile,
	trustedGetters  : arguments.trustedGetters,
	iso8601Format   : arguments.iso8601Format,
	dateMask        : arguments.dateMask,
	timeMask        : arguments.timeMask,
	autoCastBooleans: arguments.autoCastBooleans
);
```
(From the Mementifier interceptor)

The problem here is that those flags are treated as overrides even if they are defaults.  I have never set `autoCastBooleans` to true.  It is the default value.  I feel like we should treat default values as different than passed in values. Even then, passing in `autoCastBooleans` = true to the root level entity may not necessarily mean I want it all the way down, but I feel like it's closer, at least.

Take this section here inside `Mementifier.cfc`:
```
arguments.trustedGetters   = isNull( arguments.trustedGetters ) ? thisMemento.trustedGetters : arguments.trustedGetters;
arguments.iso8601Format    = isNull( arguments.iso8601Format ) ? thisMemento.iso8601Format : arguments.iso8601Format;
arguments.dateMask         = isNull( arguments.dateMask ) ? thisMemento.dateMask : arguments.dateMask;
arguments.timeMask         = isNull( arguments.timeMask ) ? thisMemento.timeMask : arguments.timeMask;
arguments.autoCastBooleans = isNull( arguments.autoCastBooleans ) ? thisMemento.autoCastBooleans : arguments.autoCastBooleans;
```
I would say we want to not param the `arguments` scope, but instead check if it's null and if it is smartly apply the default.  That way the nested `getMemento` call can do the same checks.

## Issues

[BOX-156](https://ortussolutions.atlassian.net/browse/BOX-156)

## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [x] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


[BOX-156]: https://ortussolutions.atlassian.net/browse/BOX-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ